### PR TITLE
fix the problem that unpack nginx.tar.gz

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ else
     if [ ! -e ${NGINX_SRC_VER} ]; then
         wget http://nginx.org/download/${NGINX_SRC_VER}.tar.gz
         echo "nginx Downloading ... Done"
-        tar xf ${NGINX_SRC_VER}.tar.gz
+        tar zxf ${NGINX_SRC_VER}.tar.gz
     fi
     ln -sf ${NGINX_SRC_VER} nginx_src
     NGINX_SRC=`pwd`'/nginx_src'


### PR DESCRIPTION
tar xf turn into error on alpine linux

```
d93ce71c3b86:~/ngx_mruby# sh build.sh
NGINX_CONFIG_OPT=--prefix=/root/ngx_mruby/build/nginx --with-http_stub_status_module
NUM_THREADS=1
nginx Downloading ...
Connecting to nginx.org (206.251.255.63:80)
nginx-1.9.0.tar.gz   100% |*******************************************************************************************************************************|   834k  0:00:00 ETA
nginx Downloading ... Done
tar: invalid tar magic
```

tar version is

```
d93ce71c3b86:~/ngx_mruby# tar
BusyBox v1.22.1 (2015-03-20 11:09:37 GMT) multi-call binary.
```
